### PR TITLE
Added compatibility for 'Quick Stack - Store - Sort - Trash - Restock'

### DIFF
--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -140,8 +140,8 @@ namespace ContentsWithin {
           foreach (Transform item in takeAllButton.transform.parent) {
             switch (item.name) {
               case "quickStackToContainerButton":
-			    foundModdedQuickStackButton = true;
-				item.gameObject.SetActive(ShowRealGUI());
+                foundModdedQuickStackButton = true;
+                item.gameObject.SetActive(ShowRealGUI());
                 break;
 
               case "storeAllButton":
@@ -151,14 +151,14 @@ namespace ContentsWithin {
                 break;
             }
           }
-		  
-		  // only hide when we found the modded quick stack button, in case someone is
-		  // in quickstackstore 'hotkey only' mode where it does not affect the ui
-		  if (foundModdedQuickStackButton) {
-		    // technically, this is based on a config value, but I don't think anyone
+          
+          // only hide when we found the modded quick stack button, in case someone is
+          // in quickstackstore 'hotkey only' mode where it does not affect the ui
+          if (foundModdedQuickStackButton) {
+            // technically, this is based on a config value, but I don't think anyone
             // will ever have both buttons enabled
             stackAllButton.Ref()?.SetActive(false);
-		  }
+          }
         }
 
         if (ShowRealGUI()) {

--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -133,15 +133,17 @@ namespace ContentsWithin {
 
         if (takeAllButton && Chainloader.PluginInfos.ContainsKey("goldenrevolver.quick_stack_store")) {
 
-          // technically, this is based on a config value, but I don't think anyone
-          // will ever use quickstackstore with the base game 'place stacks' button
-          stackAllButton.Ref()?.SetActive(false);
+          bool foundModdedQuickStackButton = false;
 
           // 'foreach in transform' only looks at direct children, so it's pretty performant for this use case
           // we can't save references to them because quickstackstore can destroy and respawn them in various situations
           foreach (Transform item in takeAllButton.transform.parent) {
             switch (item.name) {
               case "quickStackToContainerButton":
+			    foundModdedQuickStackButton = true;
+				item.gameObject.SetActive(ShowRealGUI());
+                break;
+
               case "storeAllButton":
               case "sortContainerButton":
               case "restockFromContainerButton":
@@ -149,6 +151,14 @@ namespace ContentsWithin {
                 break;
             }
           }
+		  
+		  // only hide when we found the modded quick stack button, in case someone is
+		  // in quickstackstore 'hotkey only' mode where it does not affect the ui
+		  if (foundModdedQuickStackButton) {
+		    // technically, this is based on a config value, but I don't think anyone
+            // will ever have both buttons enabled
+            stackAllButton.Ref()?.SetActive(false);
+		  }
         }
 
         if (ShowRealGUI()) {

--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -11,7 +11,7 @@ namespace ContentsWithin {
   public class ContentsWithin : BaseUnityPlugin {
     public const string PluginGUID = "com.maxsch.valheim.contentswithin";
     public const string PluginName = "ContentsWithin";
-    public const string PluginVersion = "2.1.3";
+    public const string PluginVersion = "2.1.4";
 
     private static ConfigEntry<bool> isModEnabled;
     private static ConfigEntry<bool> startHidden;

--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -131,6 +131,26 @@ namespace ContentsWithin {
         takeAllButton.Ref()?.SetActive(ShowRealGUI());
         stackAllButton.Ref()?.SetActive(ShowRealGUI());
 
+        if (takeAllButton && Chainloader.PluginInfos.ContainsKey("goldenrevolver.quick_stack_store")) {
+
+          // technically, this is based on a config value, but I don't think anyone
+          // will ever use quickstackstore with the base game 'place stacks' button
+          stackAllButton.Ref()?.SetActive(false);
+
+          // 'foreach in transform' only looks at direct children, so it's pretty performant for this use case
+          // we can't save references to them because quickstackstore can destroy and respawn them in various situations
+          foreach (Transform item in takeAllButton.transform.parent) {
+            switch (item.name) {
+              case "quickStackToContainerButton":
+              case "storeAllButton":
+              case "sortContainerButton":
+              case "restockFromContainerButton":
+                item.gameObject.SetActive(ShowRealGUI());
+                break;
+            }
+          }
+        }
+
         if (ShowRealGUI()) {
           return;
         }

--- a/ContentsWithin/ContentsWithin.csproj
+++ b/ContentsWithin/ContentsWithin.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ContentsWithin</RootNamespace>
     <AssemblyName>ContentsWithin</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>

--- a/ContentsWithin/README.md
+++ b/ContentsWithin/README.md
@@ -43,6 +43,9 @@ Extract all files to `BepInEx/plugins/ContentsWithin`
 
 ## Changelog
 
+2.1.4
+ * Added compatibility for 'Quick Stack - Store - Sort - Trash - Restock', hiding its chest buttons when hovering over a chest
+
 2.1.3
  * Updated for Valheim 0.217.22, not compatible with older versions
  * Updated and compiled for BepInExPack 5.4.2200

--- a/ContentsWithin/manifest.json
+++ b/ContentsWithin/manifest.json
@@ -1,6 +1,6 @@
 ﻿{
     "name": "ContentsWithin",
-    "version_number": "2.1.3",
+    "version_number": "2.1.4",
     "description": "Show the contents of any chest when hovering over it",
     "website_url": "https://github.com/MSchmoecker/ComfyMods/tree/fork-upload/ContentsWithin",
     "dependencies": [


### PR DESCRIPTION
We try to find and hide the 'Quick Stack Store' buttons by name by searching for them in the Update method. Not optimal, but far from the worst, since saving references to them is not possible due to how 'Quick Stack Store' works.

The base game 'place stacks' button has to be re-hidden because 'Contents Within' is undoing the hiding from 'Quick Stack Store'.

I implemented this in a different project (because I didn't feel like fixing refs) and then manually pasted it and fixed the indentation. So before accepting, pull locally to check if it compiles.